### PR TITLE
Implement Curriculum Service and Controller for advanced course search

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
@@ -1,0 +1,79 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.documents.CourseSearchParams;
+import edu.ucsb.cs156.example.services.UCSBCurriculumService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Api(description = "API to search the UCSB courses API")
+@RequestMapping("/api/ucsbcourses")
+@RestController
+public class UCSBCurriculumController extends ApiController {
+
+    @Autowired
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @ApiOperation(value = "Run a course search with sensible defaults")
+    @GetMapping("/search")
+    public String courseSearch(
+        @ApiParam("quarter")              @RequestParam(required = true ) String quarter,
+        @ApiParam("courseId")             @RequestParam(required = false) String courseId,
+        @ApiParam("enrollCode")           @RequestParam(required = false) String enrollCode,
+        @ApiParam("session")              @RequestParam(required = false) String session,
+        @ApiParam("subjectCode")          @RequestParam(required = false) String subjectCode,
+        @ApiParam("deptCode")             @RequestParam(required = false) String deptCode,
+        @ApiParam("objLevelCode")         @RequestParam(required = false) String objLevelCode,
+        @ApiParam("title")                @RequestParam(required = false) String title,
+        @ApiParam("areas")                @RequestParam(required = false) String areas,
+        @ApiParam("openSections")         @RequestParam(required = false) Boolean openSections,
+        @ApiParam("nonRestriction")       @RequestParam(required = false) Boolean nonRestriction,
+        @ApiParam("nonPreReq")            @RequestParam(required = false) Boolean nonPreReq,
+        @ApiParam("minUnits")             @RequestParam(required = false) Double minUnits,
+        @ApiParam("maxUnits")             @RequestParam(required = false) Double maxUnits,
+        @ApiParam("minStartTime")         @RequestParam(required = false) Integer minStartTime,
+        @ApiParam("maxStartTime")         @RequestParam(required = false) Integer maxStartTime,
+        @ApiParam("days")                 @RequestParam(required = false) String days,
+        @ApiParam("instructor")           @RequestParam(required = false) String instructor,
+        @ApiParam("pageNumber")           @RequestParam(required = false, defaultValue = "1") Integer pageNumber,
+        @ApiParam("pageSize")             @RequestParam(required = false, defaultValue = "100") Integer pageSize,
+        @ApiParam("includeClassSections") @RequestParam(required = false, defaultValue = "true") Boolean includeClassSections
+    ) {
+        // Create a course search params object
+        CourseSearchParams csp = new CourseSearchParams(quarter);
+        csp.courseId = courseId;
+        csp.enrollCode = enrollCode;
+        csp.session = session;
+        csp.subjectCode = subjectCode;
+        csp.deptCode = deptCode;
+        csp.objLevelCode = objLevelCode;
+        csp.title = title;
+        csp.areas = areas;
+        csp.openSections = openSections;
+        csp.nonRestriction = nonRestriction;
+        csp.nonPreReq = nonPreReq;
+        csp.minUnits = minUnits;
+        csp.maxUnits = maxUnits;
+        csp.minStartTime = minStartTime;
+        csp.maxStartTime = maxStartTime;
+        csp.days = days;
+        csp.instructor = instructor;
+        csp.pageNumber = pageNumber;
+        csp.pageSize = pageSize;
+        csp.includeClassSections = includeClassSections;
+
+        log.info(csp.generateParams());
+
+        return ucsbCurriculumService.courseSearchAdvanced(csp);
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
@@ -75,11 +75,6 @@ public class UCSBCurriculumController extends ApiController {
         log.info(csp.generateParams());
 
         return ResponseEntity.ok().body(ucsbCurriculumService.courseSearchAdvanced(csp));
-    }
-
-    @GetMapping(value = "/subjects", produces = "application/json")
-    public ResponseEntity<String> getSubjects() {
-        return ResponseEntity.ok().body(ucsbCurriculumService.getSubjectsJSON());
-    }  
+    } 
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumController.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,7 @@ public class UCSBCurriculumController extends ApiController {
 
     @ApiOperation(value = "Run a course search with sensible defaults")
     @GetMapping("/search")
-    public String courseSearch(
+    public ResponseEntity<String> courseSearch(
         @ApiParam("quarter")              @RequestParam(required = true ) String quarter,
         @ApiParam("courseId")             @RequestParam(required = false) String courseId,
         @ApiParam("enrollCode")           @RequestParam(required = false) String enrollCode,
@@ -73,7 +74,12 @@ public class UCSBCurriculumController extends ApiController {
 
         log.info(csp.generateParams());
 
-        return ucsbCurriculumService.courseSearchAdvanced(csp);
+        return ResponseEntity.ok().body(ucsbCurriculumService.courseSearchAdvanced(csp));
     }
+
+    @GetMapping(value = "/subjects", produces = "application/json")
+    public ResponseEntity<String> getSubjects() {
+        return ResponseEntity.ok().body(ucsbCurriculumService.getSubjectsJSON());
+    }  
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/documents/CourseSearchParams.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/CourseSearchParams.java
@@ -1,0 +1,54 @@
+package edu.ucsb.cs156.example.documents;
+
+public class CourseSearchParams {
+
+    public CourseSearchParams(String quarter){
+        this.quarter = quarter;
+    }
+
+    public String quarter;
+    public String courseId;
+    public String enrollCode;
+    public String session;
+    public String subjectCode;
+    public String deptCode;
+    public String objLevelCode;
+    public String title;
+    public String areas;
+    public Boolean openSections;
+    public Boolean nonRestriction;
+    public Boolean nonPreReq;
+    public Double minUnits;
+    public Double maxUnits;
+    public Integer minStartTime;
+    public Integer maxStartTime;
+    public String days;
+    public String instructor;
+    public Integer pageNumber = 1;
+    public Integer pageSize = 100;
+    public Boolean includeClassSections = true;
+
+    public String generateParams(){
+        return String.format("?quarter=%s", quarter)
+            + (courseId != null ? String.format("&courseId=%s", courseId) : "")
+            + (enrollCode != null ? String.format("&enrollCode=%s", enrollCode) : "")
+            + (session != null ? String.format("&session=%s", session) : "")
+            + (subjectCode != null ? String.format("&subjectCode=%s", subjectCode) : "")
+            + (deptCode != null ? String.format("&deptCode=%s", deptCode) : "")
+            + (objLevelCode != null ? String.format("&objLevelCode=%s", objLevelCode) : "")
+            + (title != null ? String.format("&title=%s", title) : "")
+            + (areas != null ? String.format("&areas=%s", areas) : "")
+            + (openSections != null ? String.format("&openSections=%b", openSections) : "")
+            + (nonRestriction != null ? String.format("&nonRestriction=%b", nonRestriction) : "")
+            + (nonPreReq != null ? String.format("&nonPreReq=%b", nonPreReq) : "")
+            + (minUnits != null ? String.format("&minUnits=%f", minUnits) : "")
+            + (maxUnits != null ? String.format("&maxUnits=%f", maxUnits) : "")
+            + (minStartTime != null ? String.format("&minStartTime=%d", minStartTime) : "")
+            + (maxStartTime != null ? String.format("&maxStartTime=%d", maxStartTime) : "")
+            + (days != null ? String.format("&days=%s", days) : "")
+            + (instructor != null ? String.format("&instructor=%s", instructor) : "")
+            + String.format("&pageNumber=%d", pageNumber)
+            + String.format("&pageSize=%d", pageSize)
+            + String.format("&includeClassSections=%b", includeClassSections);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/CourseSearchParams.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/CourseSearchParams.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.example.documents;
 
+import org.springframework.web.util.UriUtils;
+
 public class CourseSearchParams {
 
     public CourseSearchParams(String quarter){
@@ -29,26 +31,26 @@ public class CourseSearchParams {
     public Boolean includeClassSections = true;
 
     public String generateParams(){
-        return String.format("?quarter=%s", quarter)
-            + (courseId != null ? String.format("&courseId=%s", courseId) : "")
-            + (enrollCode != null ? String.format("&enrollCode=%s", enrollCode) : "")
-            + (session != null ? String.format("&session=%s", session) : "")
-            + (subjectCode != null ? String.format("&subjectCode=%s", subjectCode) : "")
-            + (deptCode != null ? String.format("&deptCode=%s", deptCode) : "")
-            + (objLevelCode != null ? String.format("&objLevelCode=%s", objLevelCode) : "")
-            + (title != null ? String.format("&title=%s", title) : "")
-            + (areas != null ? String.format("&areas=%s", areas) : "")
-            + (openSections != null ? String.format("&openSections=%b", openSections) : "")
-            + (nonRestriction != null ? String.format("&nonRestriction=%b", nonRestriction) : "")
-            + (nonPreReq != null ? String.format("&nonPreReq=%b", nonPreReq) : "")
-            + (minUnits != null ? String.format("&minUnits=%f", minUnits) : "")
-            + (maxUnits != null ? String.format("&maxUnits=%f", maxUnits) : "")
-            + (minStartTime != null ? String.format("&minStartTime=%d", minStartTime) : "")
-            + (maxStartTime != null ? String.format("&maxStartTime=%d", maxStartTime) : "")
-            + (days != null ? String.format("&days=%s", days) : "")
-            + (instructor != null ? String.format("&instructor=%s", instructor) : "")
-            + String.format("&pageNumber=%d", pageNumber)
-            + String.format("&pageSize=%d", pageSize)
-            + String.format("&includeClassSections=%b", includeClassSections);
+        return String.format("?quarter=%s", UriUtils.encode(quarter, "UTF-8"))
+            + (courseId != null ? String.format("&courseId=%s", UriUtils.encode(courseId, "UTF-8")) : "")
+            + (enrollCode != null ? String.format("&enrollCode=%s", UriUtils.encode(enrollCode, "UTF-8")) : "")
+            + (session != null ? String.format("&session=%s", UriUtils.encode(session, "UTF-8")) : "")
+            + (subjectCode != null ? String.format("&subjectCode=%s", UriUtils.encode(subjectCode, "UTF-8")) : "")
+            + (deptCode != null ? String.format("&deptCode=%s", UriUtils.encode(deptCode, "UTF-8")) : "")
+            + (objLevelCode != null ? String.format("&objLevelCode=%s", UriUtils.encode(objLevelCode, "UTF-8")) : "")
+            + (title != null ? String.format("&title=%s", UriUtils.encode(title, "UTF-8")) : "")
+            + (areas != null ? String.format("&areas=%s", UriUtils.encode(areas, "UTF-8")) : "")
+            + (openSections != null ? String.format("&openSections=%s", UriUtils.encode(openSections.toString(), "UTF-8")) : "")
+            + (nonRestriction != null ? String.format("&nonRestriction=%s", UriUtils.encode(nonRestriction.toString(), "UTF-8")) : "")
+            + (nonPreReq != null ? String.format("&nonPreReq=%s", UriUtils.encode(nonPreReq.toString(), "UTF-8")) : "")
+            + (minUnits != null ? String.format("&minUnits=%s", UriUtils.encode(minUnits.toString(), "UTF-8")) : "")
+            + (maxUnits != null ? String.format("&maxUnits=%s", UriUtils.encode(maxUnits.toString(), "UTF-8")) : "")
+            + (minStartTime != null ? String.format("&minStartTime=%s", UriUtils.encode(minStartTime.toString(), "UTF-8")) : "")
+            + (maxStartTime != null ? String.format("&maxStartTime=%s", UriUtils.encode(maxStartTime.toString(), "UTF-8")) : "")
+            + (days != null ? String.format("&days=%s", UriUtils.encode(days, "UTF-8")) : "")
+            + (instructor != null ? String.format("&instructor=%s", UriUtils.encode(instructor, "UTF-8")) : "")
+            + String.format("&pageNumber=%s", UriUtils.encode(pageNumber.toString(), "UTF-8"))
+            + String.format("&pageSize=%s", UriUtils.encode(pageSize.toString(), "UTF-8"))
+            + String.format("&includeClassSections=%s", UriUtils.encode(includeClassSections.toString(), "UTF-8"));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
@@ -53,7 +53,6 @@ public class UCSBCurriculumService  {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {}", retVal);
         return retVal;
     }
 
@@ -71,17 +70,13 @@ public class UCSBCurriculumService  {
         logger.info("url=" + url);
 
         String retVal = "";
-        MediaType contentType=null;
-        HttpStatus statusCode=null;
         try {
             ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-            contentType = re.getHeaders().getContentType();
-            statusCode = re.getStatusCode();
             retVal = re.getBody();
         } catch (HttpClientErrorException e) {
+            logger.info(e.toString());
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
         return retVal;
     }
     

--- a/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
@@ -55,29 +55,4 @@ public class UCSBCurriculumService  {
         }
         return retVal;
     }
-
-    public String getSubjectsJSON() {
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("ucsb-api-version", "1.0");
-        headers.set("ucsb-api-key", this.apiKey);
-
-        HttpEntity<String> entity = new HttpEntity<>("body", headers);
-
-        String url = "https://api.ucsb.edu/students/lookups/v1/subjects";
-        logger.info("url=" + url);
-
-        String retVal = "";
-        try {
-            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-            retVal = re.getBody();
-        } catch (HttpClientErrorException e) {
-            logger.info(e.toString());
-            retVal = "{\"error\": \"401: Unauthorized\"}";
-        }
-        return retVal;
-    }
-    
 }

--- a/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
@@ -2,13 +2,10 @@ package edu.ucsb.cs156.example.services;
 
 import java.util.Arrays;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -16,14 +13,14 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import edu.ucsb.cs156.example.documents.CourseSearchParams;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Service object that wraps the UCSB Academic Curriculum API
  */
+@Slf4j
 @Service
 public class UCSBCurriculumService  {
-
-    private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
 
     @Value("${app.ucsb.api.key}")
     private String apiKey;
@@ -44,7 +41,7 @@ public class UCSBCurriculumService  {
         String params = searchParams.generateParams();
         String url = uri + params;
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String retVal = "";
         try {

--- a/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UCSBCurriculumService.java
@@ -1,0 +1,88 @@
+package edu.ucsb.cs156.example.services;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import edu.ucsb.cs156.example.documents.CourseSearchParams;
+
+/**
+ * Service object that wraps the UCSB Academic Curriculum API
+ */
+@Service
+public class UCSBCurriculumService  {
+
+    private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
+
+    @Value("${app.ucsb.api.key}")
+    private String apiKey;
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public String courseSearchAdvanced(CourseSearchParams searchParams) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String uri = "https://api.ucsb.edu/academics/curriculums/v1/classes/search";
+        String params = searchParams.generateParams();
+        String url = uri + params;
+
+        logger.info("url=" + url);
+
+        String retVal = "";
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+        logger.info("json: {}", retVal);
+        return retVal;
+    }
+
+    public String getSubjectsJSON() {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String url = "https://api.ucsb.edu/students/lookups/v1/subjects";
+        logger.info("url=" + url);
+
+        String retVal = "";
+        MediaType contentType=null;
+        HttpStatus statusCode=null;
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            contentType = re.getHeaders().getContentType();
+            statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
+        return retVal;
+    }
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,8 @@ spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 
 spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
-
 spring.mvc.format.date-time=iso
 
 app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}
 app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
+app.ucsb.api.key=${UCSB_API_KEY:${env.UCSB_API_KEY:ucsb_api_key_unset}}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -67,7 +67,6 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         csp.enrollCode = "test";
         csp.session = "test";
         csp.deptCode = "";
-        csp.objLevelCode = "test";
         csp.title = "test";
         csp.areas = "test";
         csp.objLevelCode = "A"; 
@@ -86,6 +85,44 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
 
         assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=A&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.000000&maxUnits=2.000000&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
 
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedResult, responseString);
+    }
+
+    @Test
+    public void api_search_test_2_just_for_codecov() throws Exception {
+
+        String expectedResult = "{expectedResult}";
+
+        when(ucsbCurriculumService.courseSearchAdvanced(any())).thenReturn(expectedResult);
+
+        CourseSearchParams csp = new CourseSearchParams("20222");
+
+        csp.quarter = "test";
+        csp.courseId = "test";
+        csp.enrollCode = "test";
+        csp.session = "test";
+        csp.deptCode = "";
+        csp.title = "test";
+        csp.areas = "test";
+        csp.openSections = true;
+        csp.nonRestriction = true;
+        csp.nonPreReq = true;
+        csp.minUnits = 2.0;
+        csp.maxUnits = 2.0;
+        csp.minStartTime = 1;
+        csp.maxStartTime = 1;
+        csp.days = "";
+        csp.instructor = "";
+        csp.pageNumber = 1;
+        csp.pageSize = 100;
+        csp.includeClassSections = true;
+        
         // act
         MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))
                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -83,7 +83,7 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         csp.pageSize = 100;
         csp.includeClassSections = true;
 
-        assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=A&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.000000&maxUnits=2.000000&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
+        assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=A&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.0&maxUnits=2.0&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
 
         // act
         MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -1,0 +1,96 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.UCSBCurriculumService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.documents.CourseSearchParams;
+import edu.ucsb.cs156.example.entities.User;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+@WebMvcTest(controllers = UCSBCurriculumController.class)
+@Import(TestConfig.class)
+public class UCSBCurriculumControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    public void api_search_test() throws Exception {
+
+        String expectedResult = "{expectedResult}";
+
+        when(ucsbCurriculumService.courseSearchAdvanced(any())).thenReturn(expectedResult);
+
+        CourseSearchParams csp = new CourseSearchParams("20222");
+
+        csp.quarter = "test";
+        csp.courseId = "test";
+        csp.enrollCode = "test";
+        csp.session = "test";
+        csp.deptCode = "";
+        csp.objLevelCode = "test";
+        csp.title = "test";
+        csp.areas = "test";
+        csp.openSections = true;
+        csp.nonRestriction = true;
+        csp.nonPreReq = true;
+        csp.minUnits = 2.0;
+        csp.maxUnits = 2.0;
+        csp.minStartTime = 1;
+        csp.maxStartTime = 1;
+        csp.days = "";
+        csp.instructor = "";
+        csp.pageNumber = 1;
+        csp.pageSize = 100;
+        csp.includeClassSections = true;
+
+        assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=test&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.000000&maxUnits=2.000000&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -131,18 +131,4 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedResult, responseString);
     }
-
-    @Test
-    public void test_getSubjects() throws Exception {
-
-        String expectedResult = "[]";
-        String url = "/api/ucsbcourses/subjects";
-        when(ucsbCurriculumService.getSubjectsJSON()).thenReturn(expectedResult);
-
-        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
-                .andReturn();
-        String responseString = response.getResponse().getContentAsString();
-
-        assertEquals(expectedResult, responseString);
-    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -70,6 +70,7 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         csp.objLevelCode = "test";
         csp.title = "test";
         csp.areas = "test";
+        csp.objLevelCode = "A"; 
         csp.openSections = true;
         csp.nonRestriction = true;
         csp.nonPreReq = true;
@@ -83,7 +84,7 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         csp.pageSize = 100;
         csp.includeClassSections = true;
 
-        assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=test&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.000000&maxUnits=2.000000&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
+        assertEquals(csp.generateParams(), "?quarter=test&courseId=test&enrollCode=test&session=test&deptCode=&objLevelCode=A&title=test&areas=test&openSections=true&nonRestriction=true&nonPreReq=true&minUnits=2.000000&maxUnits=2.000000&minStartTime=1&maxStartTime=1&days=&instructor=&pageNumber=1&pageSize=100&includeClassSections=true");
 
         // act
         MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBCurriculumControllerTests.java
@@ -122,13 +122,27 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
         csp.pageNumber = 1;
         csp.pageSize = 100;
         csp.includeClassSections = true;
-        
+
         // act
         MvcResult response = mockMvc.perform(get("/api/ucsbcourses/search" + csp.generateParams()))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
         String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedResult, responseString);
+    }
+
+    @Test
+    public void test_getSubjects() throws Exception {
+
+        String expectedResult = "[]";
+        String url = "/api/ucsbcourses/subjects";
+        when(ucsbCurriculumService.getSubjectsJSON()).thenReturn(expectedResult);
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+
         assertEquals(expectedResult, responseString);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
@@ -77,9 +77,6 @@ public class UCSBCurriculumServiceTest {
         assertEquals(expectedResult, result);
     }
 
-
-
-
     @Test
     public void test_getSubjectsJSON_success() throws Exception {
         String expectedResult = "[ {deptCode: \"ANTH\"} ]";

--- a/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
@@ -77,22 +77,4 @@ public class UCSBCurriculumServiceTest {
         assertEquals(expectedResult, result);
     }
 
-    @Test
-    public void test_getSubjectsJSON_success() throws Exception {
-        String expectedResult = "[ {deptCode: \"ANTH\"} ]";
-        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
-                .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
-        String result = ucs.getSubjectsJSON();
-        assertEquals(expectedResult, result);
-    }
-
-    @Test
-    public void test_getSubjectsJSON_exception() throws Exception {
-        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
-        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
-                .thenThrow(HttpClientErrorException.class);
-        String result = ucs.getSubjectsJSON();
-        assertEquals(expectedResult, result);
-    }
-
 }

--- a/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/UCSBCurriculumServiceTest.java
@@ -1,0 +1,101 @@
+package edu.ucsb.cs156.example.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+import edu.ucsb.cs156.example.documents.CourseSearchParams;
+
+import org.springframework.web.client.HttpClientErrorException;
+
+@ExtendWith(SpringExtension.class)
+public class UCSBCurriculumServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private UCSBCurriculumService ucs;
+
+    class correctHeaders implements ArgumentMatcher<HttpEntity> {
+
+        @Override
+        public boolean matches(HttpEntity stub) {
+            return
+                stub.getHeaders().containsKey("ucsb-api-version")
+                && stub.getHeaders().containsKey("ucsb-api-key")
+                && stub.getHeaders().containsKey("accept")
+                && stub.getHeaders().containsKey("content-type");
+        }
+        
+    }
+
+    @Test
+    public void test_courseSearchAdvanced_success() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
+
+        CourseSearchParams csp = new CourseSearchParams("20221");
+        csp.subjectCode= "CMPSC";
+        csp.objLevelCode = "L";
+
+        String result = ucs.courseSearchAdvanced(csp);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_courseSearchAdvanced_exception() throws Exception {
+
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
+                .thenThrow(HttpClientErrorException.class);
+
+
+        CourseSearchParams csp = new CourseSearchParams("20221");
+        csp.subjectCode= "CMPSC";
+        csp.objLevelCode = "L";
+
+        String result = ucs.courseSearchAdvanced(csp);
+
+        assertEquals(expectedResult, result);
+    }
+
+
+
+
+    @Test
+    public void test_getSubjectsJSON_success() throws Exception {
+        String expectedResult = "[ {deptCode: \"ANTH\"} ]";
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
+        String result = ucs.getSubjectsJSON();
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getSubjectsJSON_exception() throws Exception {
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), argThat(new correctHeaders()), eq(String.class)))
+                .thenThrow(HttpClientErrorException.class);
+        String result = ucs.getSubjectsJSON();
+        assertEquals(expectedResult, result);
+    }
+
+}


### PR DESCRIPTION
# Overview

In this PR we add the `api/ucsbcourses/search` endpoint which mirrors the course search endpoint on the UCSB api. Has sensible defaults for pagination.

# Issues Addressed

This PR takes care of issue #3 and #5 

# Details

This extends the functionality in S21 prod by allowing the combination of any options to the search endpoint. It might be interesting to allow for whitelist and blacklist options and data reformatting. Courses have titles like "    ANTH          152C" So reformatting this style of data may be useful. Furthermore the ability to include only courses with "ENGR-F" GE and exclude "ENGR-WRT" courses would be very useful
