### PR TITLE
Remove Archival on Subjects Backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
@@ -1,41 +1,20 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.UCSBSubject;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.repositories.UCSBSubjectRepository;
 import edu.ucsb.cs156.example.services.UCSBSubjectsService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import lombok.extern.slf4j.Slf4j;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
-
-@Slf4j
 @Api(description = "API to handle CRUD operations for UCSB Subjects database")
 @RequestMapping("/api/UCSBSubjects")
 @RestController
 public class UCSBSubjectsController extends ApiController {
-    @Autowired
-    UCSBSubjectRepository subjectRepository;
-
-    @Autowired
-    ObjectMapper mapper;
 
     @Autowired
     UCSBSubjectsService ucsbSubjectsService;
@@ -43,66 +22,7 @@ public class UCSBSubjectsController extends ApiController {
     @ApiOperation(value = "Get all UCSB Subjects")
     @PreAuthorize("hasRole('ROLE_USER') || hasRole('ROLE_ADMIN')")
     @GetMapping("/all")
-    public Iterable<UCSBSubject> allSubjects() {
-        Iterable<UCSBSubject> subjects = subjectRepository.findAll();
-        return subjects;
+    public String allSubjects() {
+        return ucsbSubjectsService.getJSON();
     }
-
-    @ApiOperation(value = "Load subjects into database from UCSB API")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/load")
-    public List<UCSBSubject> loadSubjects() throws JsonProcessingException{
-       
-        List<UCSBSubject> subjects = ucsbSubjectsService.get();
-        
-        List<UCSBSubject> savedSubjects = new ArrayList<UCSBSubject>();
-
-        subjects.forEach((ucsbSubject)->{
-            try {
-              subjectRepository.save(ucsbSubject);
-              savedSubjects.add(ucsbSubject);
-            } catch (DuplicateKeyException dke) {
-                log.info("Skipping duplicate entity %s".formatted(ucsbSubject.getSubjectCode()));
-            }
-        });
-        log.info("subjects={}",subjects);
-        return savedSubjects;
-    }
-
-    @ApiOperation(value = "Get a single UCSB Subject by id if it is in the database")
-    @PreAuthorize("hasRole('ROLE_USER') || hasRole('ROLE_ADMIN')")
-    @GetMapping("")
-    public UCSBSubject getSubjectById(
-            @ApiParam("subjectCode") @RequestParam String subjectCode) throws JsonProcessingException {
-
-        UCSBSubject subject = subjectRepository.findById(subjectCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBSubject.class, subjectCode));
-
-        return subject;
-    }
-
-    @ApiOperation(value = "Delete a UCSB Subject by id")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("")
-    public Object deleteSubject(
-            @ApiParam("subjectCode") @RequestParam String subjectCode) {
-
-        UCSBSubject subject = subjectRepository.findById(subjectCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBSubject.class, subjectCode));
-
-        subjectRepository.delete(subject);
-
-        return genericMessage("UCSBSubject with id %s deleted".formatted(subjectCode));
-    }
-
-    @ApiOperation(value = "Delete all UCSB Subjects in the table")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/all")
-    public Object deleteAllSubjects() {
-
-        subjectRepository.deleteAll();
-
-        return genericMessage("All UCSBSubject records deleted");
-    }
-
 }

--- a/src/main/java/edu/ucsb/cs156/example/services/UCSBSubjectsService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/UCSBSubjectsService.java
@@ -1,20 +1,9 @@
 package edu.ucsb.cs156.example.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-
-import edu.ucsb.cs156.example.entities.UCSBSubject;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -24,26 +13,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.beans.factory.annotation.Value;
 
-
-@Slf4j
 @Service("UCSBSubjects")
 public class UCSBSubjectsService {
 
         @Value("${app.ucsb.api.key}") private String ucsbApiKey;
 
-        ObjectMapper mapper = new ObjectMapper();
-
         private RestTemplate restTemplate = new RestTemplate();
-
-        public UCSBSubjectsService(RestTemplateBuilder restTemplateBuilder) {
-                restTemplate = restTemplateBuilder.build();
-        }
 
         public static final String ENDPOINT = "https://api.ucsb.edu/students/lookups/v1/subjects?includeInactive=false";
         
         public String getJSON() throws HttpClientErrorException {
                 HttpHeaders headers = new HttpHeaders();
-                headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+                headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
                 headers.setContentType(MediaType.APPLICATION_JSON);
                 headers.set("ucsb-api-key", this.ucsbApiKey);
                 headers.set("ucsb-api-version", "1.6");
@@ -52,17 +33,5 @@ public class UCSBSubjectsService {
 
                 ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
                 return re.getBody();
-        }
-
-        public List<UCSBSubject> get() throws JsonProcessingException {
-
-                List<UCSBSubject> subjectsList = new ArrayList<UCSBSubject>();
-                
-                String json = getJSON();
-                UCSBSubject[] subjects = mapper.readValue(json, UCSBSubject[].class);
-                subjectsList = new ArrayList(Arrays.asList(subjects));
-                log.info("subjectsList={}",subjectsList);
-
-                return subjectsList;
         }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
@@ -4,48 +4,35 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.services.UCSBSubjectsService;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.UCSBSubject;
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.repositories.UCSBSubjectRepository;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestTemplate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-// import com.mongodb.DuplicateKeyException;
-
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doNothing;
 
 @WebMvcTest(controllers = UCSBSubjectsController.class)
 @Import(TestConfig.class)
 public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
     @MockBean
-    UCSBSubjectRepository ucsbSubjectRepository;
-
-    @MockBean
     UserRepository userRepository;
 
     @MockBean
     UCSBSubjectsService ucsbSubjectsService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
 
     @Test
     public void api_UCSBSubjects_all__logged_out__returns_403() throws Exception {
@@ -60,290 +47,20 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
                 .andExpect(status().isOk());
     }
 
-    // Tests with mocks for database actions
-
     @WithMockUser(roles = { "USER" })
     @Test
-    public void api_UCSBSubjects__user_logged_in__returns_a_subject_that_exists() throws Exception {
+    public void api_search_test() throws Exception {
 
-        // arrange
+        String expectedResult = "{expectedResult}";
 
-        User u = currentUserService.getCurrentUser().getUser();
-
-        UCSBSubject us = UCSBSubject.builder()
-                .subjectCode("ANTH")
-                .subjectTranslation("Anthropology")
-                .deptCode("ANTH")
-                .collegeCode("L&S")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.of(us));
-
-        // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?subjectCode=ANTH"))
-                .andExpect(status().isOk()).andReturn();
-
-        // assert
-
-        verify(ucsbSubjectRepository, times(1)).findById("ANTH");
-        String expectedJson = mapper.writeValueAsString(us);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
-
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void api_UCSBSubjects__user_logged_in__search_for_id_that_does_not_exist() throws Exception {
-
-        // arrange
-
-        User u = currentUserService.getCurrentUser().getUser();
-
-        when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.empty());
-
-        // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?subjectCode=ANTH"))
-                .andExpect(status().isNotFound()).andReturn();
-
-        // assert
-
-        verify(ucsbSubjectRepository, times(1)).findById("ANTH");
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("EntityNotFoundException", json.get("type"));
-        assertEquals("UCSBSubject with id ANTH not found", json.get("message"));
-    }
-
-   
-    @WithMockUser(roles = { "ADMIN", "USER" })
-    @Test
-    public void api_todos_admin_all__admin_logged_in__returns_all_records() throws Exception {
-
-        // arrange
-
-        UCSBSubject us1 = UCSBSubject.builder()
-                .subjectCode("ANTH")
-                .subjectTranslation("Anthropology")
-                .deptCode("ANTH")
-                .collegeCode("L&S")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us2 = UCSBSubject.builder()
-                .subjectCode("ART  CS")
-                .subjectTranslation("Art (Creative Studies)")
-                .deptCode("CRSTU")
-                .collegeCode("CRST")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us3 = UCSBSubject.builder()
-                .subjectCode("CH E")
-                .subjectTranslation("Chemical Engineering")
-                .deptCode("CNENG")
-                .collegeCode("ENGR")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        ArrayList<UCSBSubject> expectedUSs = new ArrayList<>();
-        expectedUSs.addAll(Arrays.asList(us1, us2, us3));
-
-        when(ucsbSubjectRepository.findAll()).thenReturn(expectedUSs);
+        when(ucsbSubjectsService.getJSON()).thenReturn(expectedResult);
 
         // act
         MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
-
-        verify(ucsbSubjectRepository, times(1)).findAll();
-        String expectedJson = mapper.writeValueAsString(expectedUSs);
         String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
+        assertEquals(expectedResult, responseString);
     }
-
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void api_todos__user_logged_in__delete_by_id() throws Exception {
-        // arrange
-
-        UCSBSubject us1 = UCSBSubject.builder()
-                .subjectCode("ANTH")
-                .subjectTranslation("Anthropology")
-                .deptCode("ANTH")
-                .collegeCode("L&S")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.of(us1));
-
-        // act
-        MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects?subjectCode=ANTH")
-                        .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
-
-        // assert
-        verify(ucsbSubjectRepository, times(1)).findById("ANTH");
-        verify(ucsbSubjectRepository, times(1)).delete(us1);
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("UCSBSubject with id ANTH deleted", json.get("message"));
-    }
-
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void api_todos__user_logged_in__delete_by_id_that_does_not_exist() throws Exception {
-        // arrange
-
-        when(ucsbSubjectRepository.findById(eq("ANTH"))).thenReturn(Optional.empty());
-
-        // act
-        MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects?subjectCode=ANTH")
-                        .with(csrf()))
-                .andExpect(status().isNotFound()).andReturn();
-
-        // assert
-        verify(ucsbSubjectRepository, times(1)).findById("ANTH");
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("UCSBSubject with id ANTH not found", json.get("message"));
-    }
-
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void api_todos__admin_logged_in__delete_all() throws Exception {
-        // arrange
-
-        doNothing().when(ucsbSubjectRepository).deleteAll();
-
-        // act
-        MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects/all")
-                        .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
-
-        // assert
-        verify(ucsbSubjectRepository, times(1)).deleteAll();
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("All UCSBSubject records deleted", json.get("message"));
-    }
-
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void api_UCSBSubjects_load_returns_200() throws Exception {
-
-        // TODO: mock the service that gets a list of subjects
-        // from the UCSB Developer API, and the list of subjects
-        // returned from that service.
-
-        // TODO: Mock the storing in the database of those records.
-
-        UCSBSubject us1 = UCSBSubject.builder()
-                .subjectCode("ANTH")
-                .subjectTranslation("Anthropology")
-                .deptCode("ANTH")
-                .collegeCode("L&S")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us2 = UCSBSubject.builder()
-                .subjectCode("ART  CS")
-                .subjectTranslation("Art (Creative Studies)")
-                .deptCode("CRSTU")
-                .collegeCode("CRST")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us3 = UCSBSubject.builder()
-                .subjectCode("CH E")
-                .subjectTranslation("Chemical Engineering")
-                .deptCode("CNENG")
-                .collegeCode("ENGR")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        List<UCSBSubject> expectedUSs = new ArrayList<>();
-        expectedUSs.addAll(Arrays.asList(us1, us2, us3));
-
-        when(ucsbSubjectsService.get()).thenReturn(expectedUSs);
-
-        MvcResult response = mockMvc.perform(post("/api/UCSBSubjects/load")
-                .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
-
-        // TODO: Verify that the service was called
-        // and that the records were stored in the database,
-        // and that the JSON returned matches the JSON for those
-        // records.
-
-        String expectedJson = mapper.writeValueAsString(expectedUSs);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
-
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void api_UCSBSubjects_load_with_duplicates() throws Exception {
-
-        // TODO: mock the service that gets a list of subjects
-        // from the UCSB Developer API, and the list of subjects
-        // returned from that service.
-
-        // TODO: Mock the storing in the database of those records.
-
-        UCSBSubject us1 = UCSBSubject.builder()
-                .subjectCode("ANTH")
-                .subjectTranslation("Anthropology")
-                .deptCode("ANTH")
-                .collegeCode("L&S")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us2 = UCSBSubject.builder()
-                .subjectCode("ART  CS")
-                .subjectTranslation("Art (Creative Studies)")
-                .deptCode("CRSTU")
-                .collegeCode("CRST")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        UCSBSubject us3 = UCSBSubject.builder()
-                .subjectCode("CH E")
-                .subjectTranslation("Chemical Engineering")
-                .deptCode("CNENG")
-                .collegeCode("ENGR")
-                .relatedDeptCode(null)
-                .inactive(false)
-                .build();
-
-        List<UCSBSubject> expectedUSs = new ArrayList<>();
-        expectedUSs.addAll(Arrays.asList(us1, us2, us3));
-
-        List<UCSBSubject> expectedSavedUSs = new ArrayList<>();
-        expectedSavedUSs.addAll(Arrays.asList(us2, us3));
-
-        
-        when(ucsbSubjectsService.get()).thenReturn(expectedUSs);
-
-        when(ucsbSubjectRepository.save(us1)).thenThrow(new org.springframework.dao.DuplicateKeyException("test"));
-
-        MvcResult response = mockMvc.perform(post("/api/UCSBSubjects/load")
-                .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
-
-        String expectedJson = mapper.writeValueAsString(expectedSavedUSs);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
-
 }


### PR DESCRIPTION
# Overview

The archival of subjects on the backend leads to poor, irregular performance on the frontend as well as the possibility of outdated data. The response from the UCSB API is small enough to warrant removing this archival, and addressing the fear of overloading their API, if someone want's to perform a search through GOLD, we should make the same request as GOLD would.

# Issues Addressed

This addresses issue #53 
