### PR TITLE
Add /raw endpoint to bypass subject archiving

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsController.java
@@ -48,6 +48,13 @@ public class UCSBSubjectsController extends ApiController {
         return subjects;
     }
 
+    @ApiOperation(value = "Get all UCSB Subjects from the UCSB API")
+    @PreAuthorize("hasRole('ROLE_USER') || hasRole('ROLE_ADMIN')")
+    @GetMapping("/raw")
+    public String rawSubjects() {
+        return ucsbSubjectsService.getJSON();
+    }
+
     @ApiOperation(value = "Load subjects into database from UCSB API")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/load")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
@@ -60,6 +60,19 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void api_UCSBSubjects_raw__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/raw"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubjects_raw__user_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/raw"))
+                .andExpect(status().isOk());
+    }
+
     // Tests with mocks for database actions
 
     @WithMockUser(roles = { "USER" })
@@ -344,6 +357,23 @@ public class UCSBSubjectsControllerTests extends ControllerTestCase {
         String expectedJson = mapper.writeValueAsString(expectedSavedUSs);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_raw_test() throws Exception {
+
+        String expectedResult = "{expectedResult}";
+
+        when(ucsbSubjectsService.getJSON()).thenReturn(expectedResult);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/raw"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedResult, responseString);
     }
 
 }


### PR DESCRIPTION
# Overview

In this PR we bypass the Subjects caching layer to talk directly to the API